### PR TITLE
Dynamically add info to welcome.json on boot

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,7 @@
 FROM grafana/grafana:11.2.0
 
-COPY grafana/provisioning /etc/grafana/provisioning
-COPY grafana/plugins /var/lib/grafana/plugins
+COPY --chown=grafana grafana/provisioning /etc/grafana/provisioning
+COPY --chown=grafana grafana/plugins /var/lib/grafana/plugins
 COPY docker/entrypoint.sh /
-
-USER grafana
-EXPOSE 3000
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 export G_DIR=/var/lib/grafana
 
 export GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 export GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH="/etc/grafana/provisioning/dashboards/welcome.json"
+
+if [ -n "$VIL_ADMIN_ADDRESS" ]; then
+  export WELCOME_TEXT="\n\nGo to venus-influx-loader [admin interface]($VIL_ADMIN_ADDRESS)"
+fi
+
+cp $GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH /tmp/welcome.json.tmpl
+awk '{gsub("__WELCOME_TEXT__", ENVIRON["WELCOME_TEXT"]); print}' < /tmp/welcome.json.tmpl > $GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+rm /tmp/welcome.json.tmpl
 
 exec /run.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,16 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 export G_DIR=/var/lib/grafana
 
 export GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 export GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH="/etc/grafana/provisioning/dashboards/welcome.json"
 
-if [ -n "$VIL_ADMIN_ADDRESS" ]; then
-  export WELCOME_TEXT="\n\nGo to venus-influx-loader [admin interface]($VIL_ADMIN_ADDRESS)"
+if [ -n "$VIL_PUBLIC_URL" ]; then
+  cp $GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH /tmp/welcome.json.tmpl
+  awk '{gsub("__VIL_PUBLIC_URL__", ENVIRON["VIL_PUBLIC_URL"]); print}' < /tmp/welcome.json.tmpl > $GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+  rm /tmp/welcome.json.tmpl
 fi
-
-cp $GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH /tmp/welcome.json.tmpl
-awk '{gsub("__WELCOME_TEXT__", ENVIRON["WELCOME_TEXT"]); print}' < /tmp/welcome.json.tmpl > $GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
-rm /tmp/welcome.json.tmpl
 
 exec /run.sh

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -30,9 +30,9 @@ services:
     environment:
      - VIL_INFLUXDB_URL=http://influxdb:8086
      - VIL_GRAFANA_API_URL=http://loader:8088/grafana-api
+     - VIL_ADMIN_ADDRESS=http://localhost:8088/admin
 
 volumes:
   influxdb-storage:
   grafana-storage:
   config-storage:
-

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -30,7 +30,9 @@ services:
     environment:
      - VIL_INFLUXDB_URL=http://influxdb:8086
      - VIL_GRAFANA_API_URL=http://loader:8088/grafana-api
-     - VIL_ADMIN_ADDRESS=http://localhost:8088/admin
+     # specify URL that should be listed on Welcome dashboard
+     # to acess Venus Influx Loader Admin UI
+     - VIL_PUBLIC_URL=http://localhost:8088/
 
 volumes:
   influxdb-storage:

--- a/grafana/provisioning/dashboards/welcome.json
+++ b/grafana/provisioning/dashboards/welcome.json
@@ -40,7 +40,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# Venus Grafana\n\nWelcome to Grafana for Venus OS.\n\nThe following dashboards allow you to quickly assess state of all your monitored Venus OS devices.\n\nClick the link on each dashboard to dive into more details about each component.",
+        "content": "# Venus Grafana\n\nWelcome to Grafana for Venus OS.\n\nThe following dashboards allow you to quickly assess state of all your monitored Venus OS devices.\n\nClick the link on each dashboard to dive into more details about each component.__WELCOME_TEXT__",
         "mode": "markdown"
       },
       "pluginVersion": "9.5.3",

--- a/grafana/provisioning/dashboards/welcome.json
+++ b/grafana/provisioning/dashboards/welcome.json
@@ -40,7 +40,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# Venus Grafana\n\nWelcome to Grafana for Venus OS.\n\nThe following dashboards allow you to quickly assess state of all your monitored Venus OS devices.\n\nClick the link on each dashboard to dive into more details about each component.__WELCOME_TEXT__",
+        "content": "# Venus Grafana\n\nWelcome to Grafana for Venus OS.\n\nThe following dashboards allow you to quickly assess state of all your monitored Venus OS devices.\n\nClick the link on each dashboard to dive into more details about each component.\n\nVisit the [Admin UI](__VIL_PUBLIC_URL__) to select Venus devices for monitoring.",
         "mode": "markdown"
       },
       "pluginVersion": "9.5.3",


### PR DESCRIPTION
Hi Martin,

For venus-grafana-deployer I would also like to add a link to the admin interface.

As you stated Grafana doesn't support dynamic info in text fields, so I worked around it.

(of course this doesn't work with the current `examples/docker-compose.yaml`, as the version needs to be updated first)

Fixes #20 